### PR TITLE
Adds error mock to simulate connection error

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -74,11 +74,24 @@ function RedisMock() {
  */
 util.inherits(RedisMock, events.EventEmitter);
 
+function RedisErrorMock() {}
+
+RedisErrorMock.prototype.createClient = function() {
+    var client = new events.EventEmitter();
+
+    process.nextTick(function() {
+        client.emit('error', 'Connection error');
+    });
+
+    return client;
+};
+
 /*
  * Create RedisMock instance and export
  */
 var MockInstance = new RedisMock();
 module.exports = exports = MockInstance;
+module.exports.RedisErrorMock = RedisErrorMock;
 
 /**
  * RedisClient constructor

--- a/test/redis-mock.test.js
+++ b/test/redis-mock.test.js
@@ -82,3 +82,17 @@ describe("redis-mock", function () {
     });
 */
 });
+
+describe("redis-error-mock", function () {
+    it("should emit a connection error", function (done) {
+        var redis = new redismock.RedisErrorMock();
+
+        var r = redis.createClient("", "", "");
+        should.exist(r);
+
+        r.once("error", function (err) {
+            err.should.equal("Connection error");
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Adds a very basic façade to simulate a connection error. The intention is that you use the error mock in place of the standard mock when you want to test your app under failing conditions.
##### Usage:

``` javascript
var RedisErrorMock = require("redis-mock").RedisErrorMock;
var redis = new RedisErrorMock();

var client = redis.createClient(); // Emits "error"

client.on("error", function(err) {
  // Fail gracefully
});
```
