### PR TITLE
Add support for TTL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.log
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ redis-mock is a WIP, why most commands are not yet available. Currently implemen
 * keys
 * exists
 * expire
+* ttl
 
 ## Strings
 * get

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -57,6 +57,31 @@ exports.expire = function (mockInstance, key, seconds, callback) {
     mockInstance._callCallback(callback, null, result);
 }
 
+/**
+ * TTL
+ * http://redis.io/commands/ttl
+ */
+exports.ttl = function (mockInstance, key, callback) {
+    var result = 0;
+
+    var obj = mockInstance.storage[key];
+
+    if (obj) {
+
+        var seconds = mockInstance.storage[key].expires;
+        if (seconds) {
+            result = seconds;
+        } else {
+            result = -1;
+        }
+
+    } else {
+        result = -2;
+    }
+
+    mockInstance._callCallback(callback, null, result);
+};
+
 /* Converting pattern into regex */
 function patternToRegex(pattern) {
     

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -173,6 +173,11 @@ RedisClient.prototype.expire = RedisClient.prototype.EXPIRE = function (key, sec
     keyfunctions.expire.call(this, MockInstance, key, seconds, callback);
 }
 
+RedisClient.prototype.ttl = RedisClient.prototype.TTL = function (key, callback) {
+
+    keyfunctions.ttl.call(this, MockInstance, key, callback);
+}
+
 RedisClient.prototype.keys = RedisClient.prototype.KEYS = function (pattern, callback) {
 
     keyfunctions.keys.call(this, MockInstance, pattern, callback);

--- a/test/redis-mock.keys.test.js
+++ b/test/redis-mock.keys.test.js
@@ -203,6 +203,76 @@ describe("expire", function () {
 
 });
 
+describe ("ttl", function () {
+
+    it("should return within expire seconds", function (done) {
+        var r = redismock.createClient("", "", "");
+
+        r.set("test", "test", function (err, result) {
+
+            r.expire("test", 10, function (err, result) {
+
+                result.should.equal(1);
+
+                r.ttl("test", function(err, ttl) {
+                    if (err) {
+                        done(err);
+                    }
+
+                    ttl.should.be.within(0,10);
+
+                    r.del("test");
+
+                    r.end();
+
+                    done();
+                });
+            });
+
+        });
+
+    });
+
+    it("should return -2 for non-existing key", function (done) {
+
+        var r = redismock.createClient("", "", "");
+
+        r.ttl("test", function(err, ttl) {
+            if (err) {
+                done(err);
+            }
+
+            ttl.should.equal(-2);
+
+            r.end();
+
+            done();
+        });
+    });
+
+    it("should return -1 for an existing key with no EXPIRE", function (done) {
+
+        var r = redismock.createClient("", "", "");
+
+        r.set("test", "test", function (err, result) {
+            r.ttl("test", function (err, ttl) {
+                if (err) {
+                    done(err);
+                }
+
+                ttl.should.equal(-1);
+
+                r.del("test");
+
+                r.end();
+
+                done();
+            });
+        });
+    });
+
+});
+
 describe("keys", function () {
 
     var r = redismock.createClient();


### PR DESCRIPTION
Adding mock support for redis.ttl.  Tests and documentation included.  Fixes #28
