### PR TITLE
Implement key expiration via individual setTimeouts and remove expire

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -48,9 +48,19 @@ exports.expire = function (mockInstance, key, seconds, callback) {
 
   if (obj) {
 
-    mockInstance.storage[key].expires = seconds;
+    var now = new Date().getTime();
+    var milli = (seconds*1000);
+
+    if (mockInstance.storage[key]._expire) {
+      clearTimeout(mockInstance.storage[key]._expire);
+    }
+
+    mockInstance.storage[key].expires = new Date(now + milli);
+    mockInstance.storage[key]._expire = setTimeout(function() {
+      delete mockInstance.storage[key];
+    }, milli);
+
     result = 1;
-    mockInstance._toggleExpireCheck(true);
   }
 
   mockInstance._callCallback(callback, null, result);
@@ -67,8 +77,10 @@ exports.ttl = function (mockInstance, key, callback) {
 
   if (obj) {
 
-    var seconds = mockInstance.storage[key].expires;
-    if (seconds) {
+    var now = new Date().getTime();
+    var expires = mockInstance.storage[key].expires instanceof Date ? mockInstance.storage[key].expires.getTime() : -1;
+    var seconds = (expires - now) / 1000;
+    if (seconds > 0) {
       result = seconds;
     } else {
       result = -1;

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -18,40 +18,6 @@ function RedisMock() {
 
   var self = this;
 
-  this._expireCheck = function () {
-    var found = false;
-    for (var s in self.storage) {
-      if (self.storage[s].expires > 0) {
-        self.storage[s].expires--;
-        found = true;
-      }
-      else if (self.storage[s].expires == 0) {
-        delete self.storage[s];
-        found = true;
-      }
-    }
-
-    if (!found) {
-      self._toggleExpireCheck(false);
-    }
-  };
-
-  this._toggleExpireCheck = function (toggle) {
-    if (!toggle) {
-      if (this._expireLoop) {
-        clearInterval(this._expireLoop);
-        this._expireLoop = null;
-      }
-    }
-    else {
-      if (!this._expireLoop) {
-        this._expireLoop = setInterval(this._expireCheck, 1000);
-      }
-
-    }
-
-  };
-
   /**
    * Helper function to launch the callback(err, reply)
    * on the next process tick

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -45,7 +45,7 @@ function RedisMock() {
     }
     else {
       if (!this._expireLoop) {
-        this._expireLoop = setInterval(this._expireCheck, 100);
+        this._expireLoop = setInterval(this._expireCheck, 1000);
       }
 
     }

--- a/test/redis-mock.keys.test.js
+++ b/test/redis-mock.keys.test.js
@@ -171,7 +171,7 @@ describe("ttl", function () {
 
         result.should.equal(1);
 
-        clock.tick(500);
+        clock.tick(5000);
         r.ttl("test", function (err, ttl) {
           if (err) {
             done(err);


### PR DESCRIPTION
I noticed there was a bug in the expire loop interval, which was mirrored in the tests (which is why they were passing).

1s was specified as 100ms, when it should be 1000.

Instead of just fixing that, I swapped in something that should be significantly more accurate when expiring keys.  I also fixed the tests.

