### PR TITLE
Call callback after selecting database

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -395,8 +395,8 @@ RedisClient.prototype.send_command = RedisClient.prototype.SEND_COMMAND = functi
   }
 }
 
-RedisClient.prototype.select = function (database) {
-
+RedisClient.prototype.select = function (database, callback) {
+  process.nextTick(callback);
   return "OK";
 }
 
@@ -417,8 +417,3 @@ RedisMock.prototype.createClient = function (port_arg, host_arg, options) {
 
   return new RedisClient();
 }
-
-
-
-
-

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -396,7 +396,9 @@ RedisClient.prototype.send_command = RedisClient.prototype.SEND_COMMAND = functi
 }
 
 RedisClient.prototype.select = function (database, callback) {
-  process.nextTick(callback);
+  if (callback) {
+    process.nextTick(callback(null, "OK"));
+  }
   return "OK";
 }
 

--- a/test/redis-mock.test.js
+++ b/test/redis-mock.test.js
@@ -31,6 +31,15 @@ describe("redis-mock", function () {
 
   });
 
+  it("should call a callback when selecting a database", function (done) {
+    var r = redismock.createClient();
+
+    r.select(0, function(error) {
+      should.not.exist(error);
+      done();
+    });
+  });
+
   it("should emit ready and connected when creating client", function (done) {
 
     var r = redismock.createClient();
@@ -85,13 +94,13 @@ describe("redis-mock", function () {
 
 describe("redis-error-mock", function () {
     it("should emit a connection error", function (done) {
-		
+
 		// Skip this when testing against actual Redis
 		if (process.env['VALID_TESTS']) {
 			done();
 			return;
 		}
-		
+
         var redis = new redismock.RedisErrorMock();
 
         var r = redis.createClient();


### PR DESCRIPTION
The `select` method in the main redis client [takes a callback as it's second argument](https://github.com/mranney/node_redis/blob/master/index.js#L1004-L1017).  This callback brings `redis-mock` in line with that.
