### PR TITLE
Clear timeouts when deleting keys

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -18,6 +18,7 @@ exports.del = function (mockInstance, keys, callback) {
 
     if (keys[i] in mockInstance.storage) {
 
+      clearTimeout(mockInstance.storage[keys[i]]._expire);
       delete mockInstance.storage[keys[i]];
       keysDeleted++;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,6 +8,10 @@
  * flushdb
  */
 exports.flushdb = flushdb = function (mockInstance, callback) {
+  for (var key in mockInstance.storage) {
+      clearTimeout(mockInstance.storage[key]._expire);
+  }
+
   mockInstance.storage = {};
 
   mockInstance._callCallback(callback, null, 'OK');


### PR DESCRIPTION
This helps in tests, so that simply calling flushdb at the end of a test will clear timeouts so that the process can exit. The _expire timeouts are also cleared when deleting individual keys to guarantee a clean exit.
