### PR TITLE
Make hget return null for missing keys of existing hashes

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -18,7 +18,9 @@ exports.hget = function (mockInstance, hash, key, callback) {
 
   if (mockInstance.storage[hash]) {
     if (mockInstance.storage[hash].type === "hash") {
-      value = mockInstance.storage[hash].value[key];
+      if (typeof mockInstance.storage[hash].value[key] !== 'undefined') {
+        value = mockInstance.storage[hash].value[key];
+      }
     } else {
       err = new Error("WRONGTYPE Operation against a key holding the wrong kind of value");
     }


### PR DESCRIPTION
Node-Redis returns `null` if a hash exists but the requested key doesn't. Redis-Mock returns `undefined` in that case.